### PR TITLE
Restore user-specific backup

### DIFF
--- a/sysadmin/README.md
+++ b/sysadmin/README.md
@@ -22,5 +22,5 @@ This directory contains scripts for configuration, operation and upkeep of Fedor
     ./configure_system.sh
     ```
 
-1. Open the `Backups` application and restore your home directory from the backup at `/mnt/Backup/duplicity`.
+1. Open the `Backups` application and restore your home directory from your backup at `/mnt/Backup`.
 1. Restart your computer to apply the user settings that were restored from the backup.


### PR DESCRIPTION
Instead of storing a single common backup `/mnt/Backup/duplicity`, instead store user-specific backups `/mnt/Backup/<USER_NAME>`. This allows me to use permissions to only allow access to your own backup.